### PR TITLE
Add an ouija-archives feature and make the command prefix configurable.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ The `.env` file should look like this:
 DISCORD_TOKEN=NDU0NDA3Mzk2MzQxODQxOTY3.DftMXw.Scfd1sM2rEGWNSnbOquqcWmmnxY
 # Replace the ID number with the client ID for your instance of the Discord bot.
 DISCORD_CLIENT_ID=454407396341841967
+OUIJA_PREFIX=ouija!
 ```
 
 - Enter the postgres CLI with `psql` and run `CREATE DATABASE ouijabot;`, this should create the database.

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -5,8 +5,8 @@ client_id_environment_variable: "DISCORD_CLIENT_ID"
 # Discord API client token environment variable
 token_environment_variable: "DISCORD_TOKEN"
 
-# Command prefix
-prefix: "ouija!"
+# Command prefix environment variable
+prefix_environment_variable: "OUIJA_PREFIX"
 
 # ID of bot owner
 owner: 151162710757867521

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -18,7 +18,7 @@ module Bot
   # can access the cache anywhere.
   BOT = Discordrb::Commands::CommandBot.new(client_id: ENV[CONFIG.client_id_environment_variable.to_s],
                                             token: ENV[CONFIG.token_environment_variable.to_s],
-                                            prefix: CONFIG.prefix)
+                                            prefix: ENV[CONFIG.prefix_environment_variable.to_s] || "ouija!")
 
   # This class method wraps the module lazy-loading process of discordrb command
   # and event modules. Any module name passed to this method will have its child

--- a/src/modules/commands/settings.rb
+++ b/src/modules/commands/settings.rb
@@ -10,7 +10,7 @@ module Bot::DiscordCommands
         "`Ouija Mode`: #{settings[:enabled] ? 'Enabled' : 'Disabled'}\n"\
         "`Delete All Mode`: #{settings[:delete_all] ? 'Enabled' : 'Disabled'}\n"\
         "`Current Question`: #{settings[:current_question]}\n"\
-        "`Archive Mode`: #{settings[:archive] ? 'Enabled' : 'Disabled'}\n"
+        "`Archive Mode`: #{settings[:archive] ? 'Enabled' : 'Disabled'}\n"\
         "`Debug Mode`: #{settings[:debug_mode] ? 'Enabled' : 'Disabled'}\n"
       event.respond(settings_info)
     end

--- a/src/modules/commands/settings.rb
+++ b/src/modules/commands/settings.rb
@@ -10,6 +10,7 @@ module Bot::DiscordCommands
         "`Ouija Mode`: #{settings[:enabled] ? 'Enabled' : 'Disabled'}\n"\
         "`Delete All Mode`: #{settings[:delete_all] ? 'Enabled' : 'Disabled'}\n"\
         "`Current Question`: #{settings[:current_question]}\n"\
+        "`Archive Mode`: #{settings[:archive] ? 'Enabled' : 'Disabled'}\n"
         "`Debug Mode`: #{settings[:debug_mode] ? 'Enabled' : 'Disabled'}\n"
       event.respond(settings_info)
     end
@@ -35,6 +36,42 @@ module Bot::DiscordCommands
       end
 
       event.channel.send_message("Ouija mode is enabled.")
+    end
+
+    command(:enable_archive, description: "Enables Archive mode. Only available for users with the ability to manage channels.") do |event|
+      # Only allow this command if the user that triggered the event can manage
+      # channels in this server.
+      unless event.user.permission?(:manage_channels)
+        event.channel.send_temporary_message("You don't have the permissions to do this. Only users who are able to manage channels can enable/disable Archive mode.", 5)
+        break
+      end
+
+      settings = Bot::Database::Settings.find(guild_id: event.server.id)
+      if settings
+        settings.update(archive: true)
+      else
+        Bot::Database::Settings.create(guild_id: event.server.id, archive: true)
+      end
+
+      event.channel.send_message("Archive mode is enabled.")
+    end
+
+    command(:disable_archive, description: "Disables Archive mode. Only available for users with the ability to manage channels.") do |event|
+      # Only allow this command if the user that triggered the event can manage
+      # channels in this server.
+      unless event.user.permission?(:manage_channels)
+        event.channel.send_temporary_message("You don't have the permissions to do this. Only users who are able to manage channels can enable/disable Archive mode.", 5)
+        break
+      end
+
+      settings = Bot::Database::Settings.find(guild_id: event.server.id)
+      if settings
+        settings.update(archive: false)
+      else
+        Bot::Database::Settings.create(guild_id: event.server.id, archive: false)
+      end
+
+      event.channel.send_message("Archive mode is disabled.")
     end
 
     command(:disable, description: "Disables Ouija mode. Only available for users with the ability to manage channels.") do |event|

--- a/src/modules/database/migrations/004_archive.rb
+++ b/src/modules/database/migrations/004_archive.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    add_column :settings, :archive, TrueClass, default: false
+  end
+
+  down do
+    drop_column :settings, :archive
+  end
+end


### PR DESCRIPTION
Resolves #22.

The command prefix is now configurable using environment variables.